### PR TITLE
ci: renovate の挙動を確認するためのワークフローを追加

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -1,0 +1,75 @@
+name: dry run
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        default: main
+        required: true
+        type: string
+      path:
+        default: renovate.json5
+        required: true
+        type: string
+
+env:
+  TZ: Asia/Tokyo
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+        with:
+          node-version-file: 'package.json'
+      - id: npm-cache
+        run: echo "dir=$(npm config get cache)" | tee -a "$GITHUB_OUTPUT"
+      - id: cache-key
+        run: >
+          echo 'suffix=${{ format('{0}-{1}-{2}', runner.os, runner.arch, hashFiles('package-lock.json')) }}'
+          | tee -a "$GITHUB_OUTPUT"
+      - id: restore-cache
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: |
+            node_modules
+            ${{ steps.npm-cache.outputs.dir }}
+          key: npm-${{ steps.cache-key.outputs.suffix }}
+          restore-keys: |
+            npm-${{ steps.restore-key.outputs.suffix }}
+            npm-
+      - if: steps.restore-cache.outputs.cache-hit != 'true'
+        run: npm ci --ignore-scripts
+        env:
+          NPM_CONFIG_AUDIT: false
+          NPM_CONFIG_PROGRESS: false
+          NPM_CONFIG_PREFER_OFFLINE: true
+      - run: npm rebuild && npm run prepare --if-present
+      - run: >
+          npx renovate --dry-run=full --print-config '${{ github.repository }}'
+          | tee "${GITHUB_REF}.txt"
+        env:
+          LOG_LEVEL: debug
+          RENOVATE_BASE_BRANCHES: ${{ inputs.ref }}
+          RENOVATE_CONFIG_FILE: ${{ inputs.path }}
+          RENOVATE_GIT_AUTHOR: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>
+          RENOVATE_TOKEN: ${{ github.token }}
+          RENOVATE_USERNAME: renovate[bot]
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          if-no-files-found: error
+          include-hidden-files: false
+          name: 'renovate-log-${{ github.ref }}'
+          path: '${{ github.ref }}.txt'
+          retention-days: 1
+      - if: github.ref_name == 'main'
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: |
+            node_modules
+            ${{ steps.npm-cache.outputs.dir }}
+          key: npm-${{ steps.cache-key.outputs.suffix }}

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -64,6 +64,7 @@ jobs:
           if-no-files-found: error
           include-hidden-files: false
           name: 'renovate-log-${{ github.ref }}'
+          overwrite: true
           path: '${{ github.ref }}.txt'
           retention-days: 1
       - if: github.ref_name == 'main'

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -16,7 +16,7 @@ env:
   TZ: Asia/Tokyo
 
 jobs:
-  test:
+  dry-run:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -5,10 +5,12 @@ on:
     inputs:
       ref:
         default: main
+        description: target ref
         required: true
         type: string
       path:
         default: renovate.json5
+        description: file path
         required: true
         type: string
 

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -56,7 +56,7 @@ jobs:
           LOG_LEVEL: debug
           RENOVATE_BASE_BRANCHES: ${{ inputs.ref }}
           RENOVATE_CONFIG_FILE: ${{ inputs.path }}
-          RENOVATE_GIT_AUTHOR: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>
+          RENOVATE_GIT_AUTHOR: 'renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>'
           RENOVATE_TOKEN: ${{ github.token }}
           RENOVATE_USERNAME: renovate[bot]
       - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0


### PR DESCRIPTION
#14 など、renovateの設定の確認や挙動の確認をしたいことが多々あるため、それを確認するためのワークフローを作成しました。

- https://zenn.dev/cybozu_ept/articles/compare-renovate-dry-run
- https://zenn.dev/azrsh/articles/renovate-dry-run-ci
- https://docs.renovatebot.com/configuration-options/
- https://docs.renovatebot.com/config-presets/