### PR TITLE
chore: 自動マージを週始めにするようにした

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -11,7 +11,7 @@
   packageRules: [
     {
       matchPackageNames: ['renovate'],
-      description: '更新が多すぎるので週末にのみマージする',
+      description: '更新が多すぎるので週始めにのみマージする',
       extends: ['schedule:automergeWeekly']
     }
   ]

--- a/renovate.json5
+++ b/renovate.json5
@@ -7,5 +7,12 @@
   ],
   lockFileMaintenance: {
     automerge: true
-  }
+  },
+  packageRules: [
+    {
+      matchPackageNames: ['renovate'],
+      description: '更新が多すぎるので週末にのみマージする',
+      extends: ['schedule:automergeWeekly']
+    }
+  ]
 }


### PR DESCRIPTION
renovate が更新されすぎるのでマージタイミングを週始めとするようにしました

https://docs.renovatebot.com/configuration-options/#packagerules