### PR TITLE
chore: renovateの更新PRを週次に制限

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -8,8 +8,8 @@
   packageRules: [
     {
       matchPackageNames: ['renovate'],
-      description: '更新が多すぎるので週始めにのみマージする',
-      extends: ['schedule:automergeWeekly']
+      description: '更新が多すぎるので週始めにのみPRを作成する',
+      extends: ['schedule:weekly']
     }
   ]
 }


### PR DESCRIPTION
## 概要

renovateパッケージの更新PRが頻繁に作成される問題に対応するため、PRの作成を週次（月曜日）に制限する設定を追加しました。

## 変更内容

- renovateパッケージに対して`schedule:weekly`プリセットを適用し、PRの作成を週次に制限
- 既存の自動マージ設定（`automerge-all.json5`）は維持

## 期待される効果

- renovateパッケージの更新PRが週1回（月曜日）のみ作成されるようになり、PR数が大幅に削減される
  - 現状: 1日に複数回のPRが作成される（例: 2025-02-22には6つのPRが作成）
  - 変更後: 週1回のPRのみ作成される

## 影響範囲

- renovateパッケージの更新PRの作成タイミングのみに影響
- 他のパッケージの更新設定には影響なし 