### PR TITLE
chore: 指定されたバージョンの npm を使うようにした

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version-file: 'package.json'
+      - run: npm install -g npm@$(jq -r '.engines.npm' package.json)
       - id: npm-cache
         run: echo "dir=$(npm config get cache)" | tee -a "$GITHUB_OUTPUT"
       - id: cache-key

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version-file: 'package.json'
+      - run: npm install -g npm@$(jq -r '.engines.npm' package.json)
       - uses: openameba/action-npm-cache/restore@17a85603bd7cb8a5af266b11d99440190b213bed # v1.0.0
       - run: npm test
       - if: github.ref_name == 'main'


### PR DESCRIPTION
## 変更内容

GitHub Actionsのワークフローで使用するnpmのバージョンを、package.jsonの`engines.npm`フィールドから動的に取得するように変更しました。

### 技術的な変更点

- `setup-node`アクションの後に、`jq`コマンドを使用してpackage.jsonからnpmのバージョンを取得し、指定されたバージョンをインストールするステップを追加
  ```yaml
  - run: npm install -g npm@$(jq -r '.engines.npm' package.json)
  ```

### 変更理由

1. package.jsonで指定されているnpmのバージョンと、実際に使用されるnpmのバージョンの一致を保証
2. package.jsonのnpmバージョンが更新された際に、ワークフローファイルの修正が不要になり保守性が向上

### 影響範囲

- `dry-run.yml`
- `test.yml`

いずれのファイルも同様の変更を適用しています。 