### PR TITLE
chore: ラベルを追加するようにした

### DIFF
--- a/main.json5
+++ b/main.json5
@@ -8,6 +8,7 @@
     ':configMigration',
     // Pull-requestにラベルをつける
     ':label(renovate)',
+    ':enableVulnerabilityAlertsWithLabel(security)',
     // タイムゾーンを日本時間にする
     ':timezone(Asia/Tokyo)',
     // メジャーバージョンの更新を個別に分ける


### PR DESCRIPTION
セキュリティ脆弱性アラート用のラベルを追加しました。

このPRでは、Renovateの設定に`:enableVulnerabilityAlertsWithLabel(security)`を追加しました。これにより、セキュリティ脆弱性に関連する更新プルリクエストに「security」ラベルが自動的に付与されるようになります。セキュリティ関連の更新を視覚的に区別しやすくなり、優先度の判断がしやすくなります。
