### PR TITLE
chore: format files

### DIFF
--- a/automerge-all.json5
+++ b/automerge-all.json5
@@ -1,8 +1,6 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  extends: [
-    ':automergeAll'
-  ],
+  extends: [':automergeAll'],
   lockFileMaintenance: {
     automerge: true,
     enabled: true

--- a/automerge-minor.json5
+++ b/automerge-minor.json5
@@ -1,8 +1,6 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  extends: [
-    ':automergeMinor'
-  ],
+  extends: [':automergeMinor'],
   lockFileMaintenance: {
     automerge: true,
     enabled: true

--- a/default.json
+++ b/default.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "local>openameba/renovate-config:main.json5"
-  ]
+  "extends": ["local>openameba/renovate-config:main.json5"]
 }

--- a/npm.json5
+++ b/npm.json5
@@ -8,7 +8,7 @@
     // node.js
     'group:nodeJs',
     // npm
-    "group:typescript-eslintMonorepo",
+    'group:typescript-eslintMonorepo',
     'group:definitelyTyped',
     'group:jsUnitTestNonMajor',
     'group:linters',

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,8 @@
   "packages": {
     "": {
       "devDependencies": {
+        "fixpack": "4.0.0",
+        "prettier": "3.5.3",
         "renovate": "39.200.2"
       },
       "engines": {
@@ -3730,6 +3732,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/alce": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/alce/-/alce-1.2.0.tgz",
+      "integrity": "sha512-XppPf2S42nO2WhvKzlwzlfcApcXHzjlod30pKmcWjRgLOtqoe5DMuqdiYoM6AgyXksc6A6pV4v1L/WW217e57w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esprima": "^1.2.0",
+        "estraverse": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/alce/node_modules/esprima": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
+      "integrity": "sha512-S9VbPDU0adFErpDai3qDkjq8+G05ONtKzcyNrPKg/ZKa+tf879nX2KexNU95b31UoTJjRLInNBHHHjFPoCd7lQ==",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -4755,7 +4784,6 @@
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -4854,6 +4882,16 @@
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -5195,6 +5233,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/estraverse": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+      "integrity": "sha512-25w1fMXQrGdoquWnScXZGckOv+Wes+JDnuN/+7ex3SauFRS72r2lFDec0EKPt2YD1wUJ/IrfEex+9yp4hfSOJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -5225,6 +5272,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/extend-object": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/extend-object/-/extend-object-1.0.0.tgz",
+      "integrity": "sha512-0dHDIXC7y7LDmCh/lp1oYkmv73K25AMugQI07r8eFopkW6f7Ufn1q+ETMsJjnV9Am14SlElkqy3O92r6xEaxPw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5372,6 +5426,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fixpack": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fixpack/-/fixpack-4.0.0.tgz",
+      "integrity": "sha512-5SM1+H2CcuJ3gGEwTiVo/+nd/hYpNj9Ch3iMDOQ58ndY+VGQ2QdvaUTkd3otjZvYnd/8LF/HkJ5cx7PBq0orCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "alce": "1.2.0",
+        "chalk": "^3.0.0",
+        "detect-indent": "^6.0.0",
+        "detect-newline": "^3.1.0",
+        "extend-object": "^1.0.0",
+        "rc": "^1.2.8"
+      },
+      "bin": {
+        "fixpack": "bin/fixpack"
+      }
+    },
+    "node_modules/fixpack/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/for-each": {
@@ -8524,7 +8610,6 @@
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -8540,8 +8625,7 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/re2": {
       "version": "1.21.4",
@@ -9792,7 +9876,6 @@
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "node": "22",
     "npm": "11"
   },
+  "prettier": {
+    "singleQuote": true,
+    "trailingComma": "none"
+  },
   "private": true,
   "scripts": {
     "test": "git ls-files '*.json' '*.json5' ':!:package*.json' | xargs renovate-config-validator --strict"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
   "devDependencies": {
+    "fixpack": "4.0.0",
+    "prettier": "3.5.3",
     "renovate": "39.200.2"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,12 @@
   },
   "private": true,
   "scripts": {
-    "test": "git ls-files '*.json' '*.json5' ':!:package*.json' | xargs renovate-config-validator --strict"
+    "fix": "echo fix:fixpack fix:prettier | xargs -n 1 npm run",
+    "fix:fixpack": "fixpack",
+    "fix:prettier": "prettier --write .",
+    "test": "echo test:fixpack test:prettier test:renovate-config-validator | xargs -n 1 npm run",
+    "test:fixpack": "fixpack --dryRun",
+    "test:prettier": "prettier --check .",
+    "test:renovate-config-validator": "git ls-files -- '*.json' '*.json5' ':!:package*.json' | xargs renovate-config-validator --strict"
   }
 }


### PR DESCRIPTION
あまりモジュールを追加したくなかったんですが、エディターで編集するたびにエディターの機能で自動的にフォーマットされてしまい嫌だったのでリポジトリ固有のフォーマットを追加して編集環境で差異がでないようにしました。

- **chore: fixpack と prettier を追加**
- **chore: prettier の設定を追加**
- **chore: npm-scripts を追加**
- **chore: fix**
