### PR TITLE
ci: オプションの引数の指定方法を間違えていたのを修正

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -50,7 +50,7 @@ jobs:
       - id: file
         run: echo "name=${GITHUB_REF_NAME//\//__}" | tee -a "$GITHUB_OUTPUT"
       - run: >
-          npx renovate --dry-run=full --print-config '${{ github.repository }}'
+          npx renovate --dry-run=full --print-config=true '${{ github.repository }}'
           | tee "${GITHUB_REF_NAME//\//__}.txt"
         env:
           LOG_LEVEL: debug


### PR DESCRIPTION
オプションの指定方法を間違えていて、dry-runのワークフローが意図した動作をしなかったのを修正しました

<img width="1102" alt="スクリーンショット 2025-04-09 11 27 09" src="https://github.com/user-attachments/assets/c67dd1e1-df84-48c4-a2e4-276fb9657ece" />
