### PR TITLE
chore: Renovate がマージする際は CI の結果を検査する

### DIFF
--- a/automerge-all.json5
+++ b/automerge-all.json5
@@ -1,6 +1,6 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  extends: [':automergeAll'],
+  extends: [':automergeAll', ':automergeRequireAllStatusChecks'],
   lockFileMaintenance: {
     automerge: true,
     enabled: true

--- a/automerge-minor.json5
+++ b/automerge-minor.json5
@@ -1,6 +1,6 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  extends: [':automergeMinor'],
+  extends: [':automergeMinor', ':automergeRequireAllStatusChecks'],
   lockFileMaintenance: {
     automerge: true,
     enabled: true


### PR DESCRIPTION
GitHubのautomergeが有効になっていない場合にもしかするとCIのチェックが通っていない時でもマージしていたかもしれない（デフォルト値的にないとは思う）ので、必ずCIのステータスをチェックしてね、というふうにしました。
GitHubのautomergeが有効になっていたリポジトリではおそらくRulesetも設定していることが多いので多分これまで大丈夫だったと思いますが……

- https://docs.renovatebot.com/presets-default/#automergerequireallstatuschecks
- https://docs.renovatebot.com/configuration-options/#ignoretests