### PR TITLE
feat: npm のクールダウンも 7 日にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ sharable renovate configs
 
 ### With automerge minor
 
+The automerge presets only configure automerge. Always extend them together with `main.json5`,
+which defines the `minimumReleaseAge` cooldown.
+
 ```json
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",

--- a/automerge-all.json5
+++ b/automerge-all.json5
@@ -4,7 +4,5 @@
   lockFileMaintenance: {
     automerge: true,
     enabled: true
-  },
-  // クールダウン
-  minimumReleaseAge: '7 days'
+  }
 }

--- a/automerge-all.json5
+++ b/automerge-all.json5
@@ -6,9 +6,5 @@
     enabled: true
   },
   // クールダウン
-  minimumReleaseAge: '7 days',
-  // 脆弱性修正は即時
-  vulnerabilityAlerts: {
-    minimumReleaseAge: null
-  }
+  minimumReleaseAge: '7 days'
 }

--- a/automerge-minor.json5
+++ b/automerge-minor.json5
@@ -4,7 +4,5 @@
   lockFileMaintenance: {
     automerge: true,
     enabled: true
-  },
-  // クールダウン
-  minimumReleaseAge: '7 days'
+  }
 }

--- a/automerge-minor.json5
+++ b/automerge-minor.json5
@@ -6,9 +6,5 @@
     enabled: true
   },
   // クールダウン
-  minimumReleaseAge: '7 days',
-  // 脆弱性修正は即時
-  vulnerabilityAlerts: {
-    minimumReleaseAge: null
-  }
+  minimumReleaseAge: '7 days'
 }

--- a/main.json5
+++ b/main.json5
@@ -39,6 +39,18 @@
   // クールダウン: リリースから7日経過するまで更新を保留する
   // https://docs.renovatebot.com/key-concepts/minimum-release-age/
   minimumReleaseAge: '7 days',
+  packageRules: [
+    {
+      // security:minimumReleaseAgeNpmがnpmに対して行っている除外を、
+      // トップレベルのminimumReleaseAgeが波及する全datasourceへ広げる
+      // bumpはisBumpフラグでもマッチしクールダウンが外れるため含めない
+      // lockfileUpdateとrollbackはこのプリセット群の設定では発生しないため含めない
+      // https://docs.renovatebot.com/key-concepts/minimum-release-age/#which-update-types-take-minimumreleaseage-into-account
+      description: 'release timestampを持たない更新はクールダウンの対象外にする',
+      matchUpdateTypes: ['pin', 'replacement', 'lockFileMaintenance'],
+      minimumReleaseAge: null
+    }
+  ],
   customManagers: [
     {
       // GitHub Actionsで使われているDockerイメージを更新する

--- a/main.json5
+++ b/main.json5
@@ -36,6 +36,9 @@
   lockFileMaintenance: {
     enabled: true
   },
+  // クールダウン: リリースから7日経過するまで更新を保留する
+  // https://docs.renovatebot.com/key-concepts/minimum-release-age/
+  minimumReleaseAge: '7 days',
   customManagers: [
     {
       // GitHub Actionsで使われているDockerイメージを更新する

--- a/main.json5
+++ b/main.json5
@@ -41,6 +41,15 @@
   minimumReleaseAge: '7 days',
   packageRules: [
     {
+      // config:best-practicesがextendsするsecurity:minimumReleaseAgeNpmが
+      // npmを3日に上書きしてしまうため、後続のpackageRulesで7日に戻す
+      // https://docs.renovatebot.com/presets-security/#securityminimumreleaseagenpm
+      description: 'npmパッケージのクールダウンを7日にする',
+      matchDatasources: ['npm'],
+      matchUpdateTypes: ['major', 'minor', 'patch'],
+      minimumReleaseAge: '7 days'
+    },
+    {
       // security:minimumReleaseAgeNpmがnpmに対して行っている除外を、
       // トップレベルのminimumReleaseAgeが波及する全datasourceへ広げる
       // bumpはisBumpフラグでもマッチしクールダウンが外れるため含めない

--- a/npm.json5
+++ b/npm.json5
@@ -13,9 +13,6 @@
     'group:jsUnitTestNonMajor',
     'group:linters',
     'group:postcss',
-    'group:react',
-    // npmパッケージを非公開にできなくなるまで待つ
-    // https://docs.renovatebot.com/presets-security/#securityminimumreleaseagenpm
-    'security:minimumReleaseAgeNpm'
+    'group:react'
   ]
 }


### PR DESCRIPTION
#285 で設けたクールダウンは、実は npm には効いていませんでした。`config:best-practices` が
`security:minimumReleaseAgeNpm`（3 日）を含んでいて、`packageRules` はトップレベル設定より
優先されるためです。npm も 7 日に揃えます。

あわせてクールダウンの指定を `automerge-*.json5` から `main.json5` に移しました。automerge を
使うかどうかで差が出なくなります。

コミット単位で読めます。

## 見てほしいところ

`main.json5` に追加した `packageRules` の 2 つです。

- npm 側を `matchUpdateTypes: ['major', 'minor', 'patch']` の正リストにしているのは、プリセットが
  先に置いている除外ルール（`pin` などを `null` にするもの）を後ろから上書きしないためです。
- 除外ルールに `bump` を入れていないのは、`bump` が `isBump` フラグでもマッチして通常の更新まで
  クールダウンが外れるからです。この判断が妥当か意見をもらいたいです。

## レビュー観点

- `ghcr.io` / `quay.io` のイメージを使っているリポジトリの心当たりがあれば教えてください。release
  timestamp が取れないため、通常の更新まで無期限保留になります（公開リポジトリには見当たりませんでした）。

<details>
<summary>変更前の実際の挙動</summary>

| リポジトリ構成 | npm | npm 以外 |
| --- | --- | --- |
| `main` のみ | 3 日 | なし |
| `main` + `npm` | 3 日 | なし |
| `main` + `automerge-*` | 3 日 | 7 日 |

`npm.json5` を extends しているかどうかは無関係でした。

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
